### PR TITLE
fix(slack): include recipient user in reply streams

### DIFF
--- a/docketeer-slack/src/docketeer_slack/client.py
+++ b/docketeer-slack/src/docketeer_slack/client.py
@@ -418,7 +418,7 @@ class SlackClient(ChatClient):
         }
         if self._team_id:
             data["recipient_team_id"] = self._team_id
-        if msg.kind is RoomKind.direct and msg.user_id:
+        if msg.user_id:
             data["recipient_user_id"] = msg.user_id
         payload = await self._api_post(
             "chat.startStream",
@@ -432,7 +432,7 @@ class SlackClient(ChatClient):
             channel_id=msg.room_id,
             stream_ts=stream_ts,
             thread_id=thread_id,
-            user_id=msg.user_id if msg.kind is RoomKind.direct else "",
+            user_id=msg.user_id,
         )
 
     async def append_reply_stream(self, stream: Any, text: str) -> None:

--- a/docketeer-slack/tests/test_rest.py
+++ b/docketeer-slack/tests/test_rest.py
@@ -50,14 +50,14 @@ async def test_start_reply_stream_channel(slack_client: SlackClient):
         channel_id="C1",
         stream_ts="1718.1",
         thread_id="1718",
-        user_id="",
+        user_id="U1",
     )
     body = route.calls[0].request.content.decode()
     assert "channel=C1" in body
     assert "thread_ts=1718" in body
     assert "markdown_text=hello" in body
     assert "recipient_team_id=" in body
-    assert "recipient_user_id" not in body
+    assert "recipient_user_id=U1" in body
 
 
 @respx.mock
@@ -101,6 +101,33 @@ async def test_start_reply_stream_without_team_id(slack_client: SlackClient):
     )
     body = route.calls[0].request.content.decode()
     assert "recipient_team_id" not in body
+
+
+@respx.mock
+async def test_start_reply_stream_without_user_id(slack_client: SlackClient):
+    route = respx.post("https://slack.com/api/chat.startStream")
+    route.mock(return_value=httpx.Response(200, json={"ok": True, "ts": "1718.1"}))
+    stream = await slack_client.start_reply_stream(
+        IncomingMessage(
+            message_id="C1:1718",
+            user_id="",
+            username="alice",
+            display_name="Alice",
+            text="hi",
+            room_id="C1",
+            kind=RoomKind.public,
+        ),
+        "1718",
+        "hello",
+    )
+    assert stream == SlackReplyStream(
+        channel_id="C1",
+        stream_ts="1718.1",
+        thread_id="1718",
+        user_id="",
+    )
+    body = route.calls[0].request.content.decode()
+    assert "recipient_user_id" not in body
 
 
 @respx.mock


### PR DESCRIPTION
## Summary
- include `recipient_user_id` for streamed Slack replies whenever the incoming message has a user id
- persist that user id on the stream handle so `chat.stopStream` uses the same recipient context
- cover the channel-thread and missing-user-id cases in `docketeer-slack` tests

## Validation
- `cd docketeer-slack && pytest`